### PR TITLE
Raise error when no API token set

### DIFF
--- a/lib/monkeylearn/requests.rb
+++ b/lib/monkeylearn/requests.rb
@@ -5,6 +5,10 @@ require 'monkeylearn/response'
 module Monkeylearn
   module Requests
     def request(method, path, data = nil, query_params = nil)
+      unless Monkeylearn.token
+        raise MonkeylearnError, 'Please initialize the Monkeylearn library with your API token'
+      end
+
       response = get_connection.send(method) do |req|
         url = path.to_s
         if query_params


### PR DESCRIPTION
Previously if a token wasn't set  you'd get a cryptic error:

```
TypeError: no implicit conversion of nil into String
	from /Users/harlow/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/monkeylearn-0.2/lib/monkeylearn/requests.rb:14:in `+'
	from /Users/harlow/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/monkeylearn-0.2/lib/monkeylearn/requests.rb:14:in `block in request'
```

This PR gives the users a little more context as to why things are failing.