### PR TITLE
Handle throttling correctly

### DIFF
--- a/lib/monkeylearn/requests.rb
+++ b/lib/monkeylearn/requests.rb
@@ -25,7 +25,7 @@ module Monkeylearn
       if Monkeylearn.wait_on_throttle && seconds = throttled?(response)
         # Request was throttled, wait 'seconds' seconds and retry
         sleep seconds
-        response = request(method, path, data)
+        return request(method, path, data, query_params)
       end
       Monkeylearn::Response.new(response)
     end


### PR DESCRIPTION
- request() returns a Monkeylearn::Response, but response in this context is a
  Faraday response. (fixes #8)
- also pass the query parameters, just in case