### PR TITLE
Reset faraday version

### DIFF
--- a/monkeylearn.gemspec
+++ b/monkeylearn.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.version = '3.0.0'
 
-  spec.add_dependency 'faraday', '= 0.15.0'
+  spec.add_dependency 'faraday', '>= 0.9.2'
 
   spec.licenses = ['MIT']
 


### PR DESCRIPTION
With the changes for the new v3 API you changed the required version of `faraday` from `>= 0.9.2` to `= 0.15.0`. What was your reasoning behind that?

From what I saw you are not using any new methods of `faraday`. This very recent version causes some conflicts in our project. We use other gems that require a version `< 0.10`. It would help a lot if you could re-evaluate whether the old `>= 0.9.2` might be enough. Thanks in advance!