### PR TITLE
Allow for variable versions for #classify and #extract; Re-Add #train

### DIFF
--- a/lib/monkeylearn/classifiers.rb
+++ b/lib/monkeylearn/classifiers.rb
@@ -88,6 +88,10 @@ module Monkeylearn
         request(:get, build_endpoint(module_id))
       end
 
+      def train(module_id)
+        request(:post, build_endpoint(module_id, 'train'), api_version: :v2)
+      end
+
       def deploy(module_id)
         request(:post, build_endpoint(module_id, 'deploy'))
       end

--- a/lib/monkeylearn/classifiers.rb
+++ b/lib/monkeylearn/classifiers.rb
@@ -22,6 +22,7 @@ module Monkeylearn
 
       def classify(model_id, data, options = {})
         batch_size = Monkeylearn::Validators.validate_batch_size(options[:batch_size])
+        api_version = Monkeylearn::Validators.validate_api_version(options[:api_version])
         endpoint = build_endpoint(model_id, 'classify')
 
         if Monkeylearn.auto_batch
@@ -30,7 +31,7 @@ module Monkeylearn
             if options.key? :production_model
               sliced_data[:production_model] = options[:production_model]
             end
-            request(:post, endpoint, data: sliced_data)
+            request(:post, endpoint, data: sliced_data, api_version: api_version)
           end
 
           return Monkeylearn::MultiResponse.new(responses)
@@ -39,7 +40,7 @@ module Monkeylearn
           if options.key? :production_model
               body[:production_model] = options[:production_model]
           end
-          return request(:post, endpoint, data: body)
+          return request(:post, endpoint, data: body, api_version: api_version)
         end
       end
 

--- a/lib/monkeylearn/classifiers.rb
+++ b/lib/monkeylearn/classifiers.rb
@@ -40,7 +40,7 @@ module Monkeylearn
             if options.key? :production_model
               sliced_data[:production_model] = options[:production_model]
             end
-            request(:post, endpoint, sliced_data)
+            request(:post, endpoint, data: sliced_data)
           end
 
           return Monkeylearn::MultiResponse.new(responses)
@@ -49,12 +49,12 @@ module Monkeylearn
           if options.key? :production_model
               body[:production_model] = options[:production_model]
           end
-          return request(:post, endpoint, body)
+          return request(:post, endpoint, data: body)
         end
       end
 
       def list(options = {})
-        request(:get, build_endpoint, nil, options)
+        request(:get, build_endpoint, query_params: options)
       end
 
       def create(name, options = {})
@@ -72,7 +72,7 @@ module Monkeylearn
             stopwords: options[:stopwords],
             whitelist: options[:whitelist],
         }.delete_if { |k,v| v.nil? }
-        request(:post, build_endpoint, data)
+        request(:post, build_endpoint, data: data)
       end
 
       def edit(module_id, options = {})
@@ -90,7 +90,7 @@ module Monkeylearn
             stopwords: options[:stopwords],
             whitelist: options[:whitelist],
         }.delete_if { |k,v| v.nil? }
-        request(:patch, build_endpoint(module_id), data)
+        request(:patch, build_endpoint(module_id), data: data)
       end
 
       def detail(module_id)
@@ -104,7 +104,7 @@ module Monkeylearn
       def upload_data(module_id, data)
         endpoint = build_endpoint(module_id, 'data')
 
-        request(:post, endpoint, {data: data})
+        request(:post, endpoint, data: {data: data})
       end
 
       def delete(module_id)
@@ -128,7 +128,7 @@ module Monkeylearn
         if options[:parent_id]
           data[:parent_id] = options[:parent_id]
         end
-        request(:post, build_endpoint(module_id), data)
+        request(:post, build_endpoint(module_id), data: data)
       end
 
       def detail(module_id, tag_id)
@@ -152,7 +152,7 @@ module Monkeylearn
           data = {move_data_to: options[:move_data_to]}
         end
 
-        request(:delete, endpoint, data)
+        request(:delete, endpoint, data: data)
       end
     end
   end

--- a/lib/monkeylearn/classifiers.rb
+++ b/lib/monkeylearn/classifiers.rb
@@ -1,4 +1,5 @@
 require 'monkeylearn/requests'
+require 'monkeylearn/validators'
 
 module Monkeylearn
   class << self
@@ -19,19 +20,8 @@ module Monkeylearn
         File.join('classifiers', *args) + '/'
       end
 
-      def validate_batch_size(batch_size)
-        max_size = Monkeylearn::Defaults.max_batch_size
-        if batch_size >  max_size
-          raise MonkeylearnError, "The param batch_size is too big, max value is #{max_size}."
-        end
-        true
-      end
-
       def classify(model_id, data, options = {})
-        options[:batch_size] ||= Monkeylearn::Defaults.default_batch_size
-        batch_size = options[:batch_size]
-        validate_batch_size batch_size
-
+        batch_size = Monkeylearn::Validators.validate_batch_size(options[:batch_size])
         endpoint = build_endpoint(model_id, 'classify')
 
         if Monkeylearn.auto_batch

--- a/lib/monkeylearn/configurable.rb
+++ b/lib/monkeylearn/configurable.rb
@@ -2,12 +2,13 @@ require 'monkeylearn/defaults'
 
 module Monkeylearn
   module Configurable
-    attr_accessor :token, :base_url, :retry_if_throttle, :auto_batch
+    attr_accessor :token, :base_url, :api_version, :retry_if_throttle, :auto_batch
 
     class << self
       def keys
         @keys ||= [
           :base_url,
+          :api_version,
           :token,
           :retry_if_throttle,
           :auto_batch,

--- a/lib/monkeylearn/configurable.rb
+++ b/lib/monkeylearn/configurable.rb
@@ -3,7 +3,6 @@ require 'monkeylearn/defaults'
 module Monkeylearn
   module Configurable
     attr_accessor :token, :base_url, :retry_if_throttle, :auto_batch
-    attr_writer :base_url
 
     class << self
       def keys

--- a/lib/monkeylearn/defaults.rb
+++ b/lib/monkeylearn/defaults.rb
@@ -3,8 +3,10 @@ module Monkeylearn
     # Constants
     DEFAULT_BATCH_SIZE = 200
     MAX_BATCH_SIZE = 200
+    SUPPORTED_API_VERSIONS = [:v2, :v3]
     # Configurable options
-    BASE_URL = 'https://api.monkeylearn.com/v3/'
+    BASE_URL = 'https://api.monkeylearn.com/'
+    API_VERSION = SUPPORTED_API_VERSIONS.last
     RETRY_IF_THROTTLE = true
     AUTO_BATCH = true
 
@@ -15,6 +17,10 @@ module Monkeylearn
 
       def base_url
         ENV['MONKEYLEARN_API_BASE_URL'] || BASE_URL
+      end
+
+      def api_version
+        ENV['MONKEYLEARN_API_VERSION'] || API_VERSION
       end
 
       def token
@@ -35,6 +41,10 @@ module Monkeylearn
 
       def default_batch_size
         DEFAULT_BATCH_SIZE
+      end
+
+      def supported_api_versions
+        SUPPORTED_API_VERSIONS
       end
     end
   end

--- a/lib/monkeylearn/extractors.rb
+++ b/lib/monkeylearn/extractors.rb
@@ -18,6 +18,7 @@ module Monkeylearn
 
       def extract(module_id, data, options = {})
         batch_size = Monkeylearn::Validators.validate_batch_size(options[:batch_size])
+        api_version = Monkeylearn::Validators.validate_api_version(options[:api_version])
         endpoint = build_endpoint(module_id, 'extract')
 
         if Monkeylearn.auto_batch
@@ -26,7 +27,7 @@ module Monkeylearn
             if options.key? :production_model
               sliced_data[:production_model] = options[:production_model]
             end
-            request(:post, endpoint, data: sliced_data)
+            request(:post, endpoint, data: sliced_data, api_version: api_version)
           end
           return Monkeylearn::MultiResponse.new(responses)
         else
@@ -34,7 +35,7 @@ module Monkeylearn
           if options.key? :production_model
               body[:production_model] = options[:production_model]
           end
-          return request(:post, endpoint, data: body)
+          return request(:post, endpoint, data: body, api_version: api_version)
         end
 
       end

--- a/lib/monkeylearn/extractors.rb
+++ b/lib/monkeylearn/extractors.rb
@@ -1,4 +1,5 @@
 require 'monkeylearn/requests'
+require 'monkeylearn/validators'
 
 module Monkeylearn
   class << self
@@ -15,19 +16,8 @@ module Monkeylearn
         File.join('extractors', *args) + '/'
       end
 
-      def validate_batch_size(batch_size)
-        max_size = Monkeylearn::Defaults.max_batch_size
-        if batch_size >  max_size
-          raise MonkeylearnError, "The param batch_size is too big, max value is #{max_size}."
-        end
-        true
-      end
-
       def extract(module_id, data, options = {})
-        options[:batch_size] ||= Monkeylearn::Defaults.default_batch_size
-        batch_size = options[:batch_size]
-        validate_batch_size batch_size
-
+        batch_size = Monkeylearn::Validators.validate_batch_size(options[:batch_size])
         endpoint = build_endpoint(module_id, 'extract')
 
         if Monkeylearn.auto_batch

--- a/lib/monkeylearn/extractors.rb
+++ b/lib/monkeylearn/extractors.rb
@@ -36,7 +36,7 @@ module Monkeylearn
             if options.key? :production_model
               sliced_data[:production_model] = options[:production_model]
             end
-            request(:post, endpoint, sliced_data)
+            request(:post, endpoint, data: sliced_data)
           end
           return Monkeylearn::MultiResponse.new(responses)
         else
@@ -44,13 +44,13 @@ module Monkeylearn
           if options.key? :production_model
               body[:production_model] = options[:production_model]
           end
-          return request(:post, endpoint, body)
+          return request(:post, endpoint, data: body)
         end
 
       end
 
       def list(options = {})
-        request(:get, build_endpoint, nil, options)
+        request(:get, build_endpoint, query_params: options)
       end
 
       def detail(module_id)

--- a/lib/monkeylearn/requests.rb
+++ b/lib/monkeylearn/requests.rb
@@ -5,7 +5,7 @@ require 'monkeylearn/exceptions'
 
 module Monkeylearn
   module Requests
-    def request(method, path, data = nil, query_params = nil)
+    def request(method, path, data: nil, query_params: nil)
       unless Monkeylearn.token
         raise MonkeylearnError, 'Please initialize the Monkeylearn library with your API token'
       end

--- a/lib/monkeylearn/response.rb
+++ b/lib/monkeylearn/response.rb
@@ -4,13 +4,14 @@ module Monkeylearn
 
     def initialize(raw_response)
       self.raw_response = raw_response
+      @symbolize_keys = true
     end
 
     def raw_response=(raw_response)
       @raw_response = raw_response
       @status = raw_response.status
       if raw_response.body != ''
-        @body = JSON.parse(raw_response.body, symbolize_keys: true)
+        @body = JSON.parse(raw_response.body, symbolize_keys: @symbolize_keys)
       else
         @body = nil
       end
@@ -27,17 +28,20 @@ module Monkeylearn
       self.responses = responses
     end
 
-    def body
-      responses.collect do |r|
-        r.body
-      end.reduce(:+)
-    end
-
     def responses=(responses)
       @responses = responses
+      @body = collect_body(responses)
       @plan_queries_allowed = @responses[-1].plan_queries_allowed
       @plan_queries_remaining = @responses[-1].plan_queries_remaining
       @request_queries_used = @responses.inject(0){|sum, r| sum + r.request_queries_used }
+    end
+
+    private
+
+    def collect_body(responses)
+      responses.collect do |r|
+        r.body
+      end.reduce(:+)
     end
   end
 end

--- a/lib/monkeylearn/response.rb
+++ b/lib/monkeylearn/response.rb
@@ -1,10 +1,15 @@
+require 'monkeylearn/validators'
+
 module Monkeylearn
   class Response
     attr_reader :raw_response, :status, :body, :plan_queries_allowed, :plan_queries_remaining, :request_queries_used
 
-    def initialize(raw_response)
+    def initialize(raw_response, api_version: nil)
       self.raw_response = raw_response
-      @symbolize_keys = true
+      api_version = Monkeylearn::Validators.validate_api_version(api_version)
+      # As we only support v2 and v3, this check should be fine. We cannot check
+      # for `Defaults.api_version` as that may be overwritten by `ENV`.
+      @symbolize_keys = api_version == :v3
     end
 
     def raw_response=(raw_response)

--- a/lib/monkeylearn/response.rb
+++ b/lib/monkeylearn/response.rb
@@ -35,7 +35,6 @@ module Monkeylearn
 
     def responses=(responses)
       @responses = responses
-      @query_limit_remaining = responses[-1].raw_response.headers['X-Query-Limit-Remaining'].to_i
       @plan_queries_allowed = @responses[-1].plan_queries_allowed
       @plan_queries_remaining = @responses[-1].plan_queries_remaining
       @request_queries_used = @responses.inject(0){|sum, r| sum + r.request_queries_used }

--- a/lib/monkeylearn/validators.rb
+++ b/lib/monkeylearn/validators.rb
@@ -1,0 +1,14 @@
+module Monkeylearn
+  module Validators
+    class << self
+      def validate_batch_size(size)
+        size ||= Monkeylearn::Defaults.default_batch_size
+        max_size = Monkeylearn::Defaults.max_batch_size
+        if size > max_size
+          raise MonkeylearnError, "The param batch_size is too big, max value is #{max_size}."
+        end
+        size
+      end
+    end
+  end
+end

--- a/lib/monkeylearn/validators.rb
+++ b/lib/monkeylearn/validators.rb
@@ -9,6 +9,15 @@ module Monkeylearn
         end
         size
       end
+
+      def validate_api_version(version)
+        version ||= Monkeylearn::Defaults.api_version
+        supported_versions = Monkeylearn::Defaults.supported_api_versions
+        unless supported_versions.include? version
+          raise MonkeylearnError, "The param api_version `#{version}` is not supported, choose from #{supported_versions.join(', ')}."
+        end
+        version
+      end
     end
   end
 end


### PR DESCRIPTION
Recently, I was upgrading the gem from `v0.2.1` to `v3.0.1` and I found a lot of breaking changes, mainly in the response formats of classifications and extractions. This makes the process really hard for large code bases.

This patch enables applications to use different API versions for retrieving the classifications and extractions so users can gradually adopt the new v3 API. This patch does not change how the new/current gem handles the configuration of models or how training data is uploaded to a (classification) model.

The patch also re-introduces the `train` method from `v0.2.1`. Under the hood, it just talks to the v2 endpoints of your back-end.

I validated the patch by uploading some training samples to a v2 model and training it, but I'm not 100% sure that I didn't break anything. I would feel better, if there would be some testing framework.

What do you think of it? I'd be happy to incorporate your feedback and iterate on this! 🙂