### PR TITLE
Update upper version restriction on Faraday dependency

### DIFF
--- a/monkeylearn.gemspec
+++ b/monkeylearn.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.version = '3.3.1'
 
-  spec.add_dependency 'faraday', '>= 0.9.2', '<= 0.15.0'
+  spec.add_dependency 'faraday', '>= 0.9.2', '< 1.0.0'
 
   spec.licenses = ['MIT']
 

--- a/monkeylearn.gemspec
+++ b/monkeylearn.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email = ['hello@monkeylearn.com']
   spec.homepage = 'https://github.com/monkeylearn/monkeylearn-ruby'
 
-  spec.version = '3.3.1'
+  spec.version = '3.3.2'
 
   spec.add_dependency 'faraday', '>= 0.9.2', '< 1.0.0'
 


### PR DESCRIPTION
Faraday `0.17` is the default version install with `ruby`, this is still compatible with `monkeylearn` library, thus this PR updates the upper restriction to keep let it be kept and avoid a forced downgrade to `0.15`.

Still, the restriction forces a version lower than `1.0.0`, when Farday 1.0 is released, we can look into upgrading to it.