### PR TITLE
Warn about usage of db_name parameter

### DIFF
--- a/lib/monkeylearn/workflows.rb
+++ b/lib/monkeylearn/workflows.rb
@@ -29,10 +29,13 @@ module Monkeylearn
       end
 
       def create(name, options = {})
+        if options[:db_name]
+          warn 'Note: db_name parameter is ignored by the API and will be removed soon'
+        end
+
         data = {
             name: name,
             description: options[:description],
-            db_name: options[:db_name],
             webhook_url: options[:webhook_url],
             steps: options[:steps],
             custom_fields: options[:custom_fields],


### PR DESCRIPTION
`db_name` usage is being deprecated from the API, an automatically generated name will be provided instead. This PR warns users about the parameter removal in a future release.